### PR TITLE
Add grafana embedding guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Dashboard extension examples and tools for Cloud Pak for AIOps
 [Components](src/components) are the widgets that comprise your dashboard. Components must be exported as [panels](src/panels) to be used in a dashboard region. These are written in React.js, and we recommend [Carbon Design System](https://carbondesignsystem.com/) as the UI framework, although you may use any React.js compatible library.
 
 ## Data
-For convenience, a [query hook](src/helpers/useQuery.ts) is provided that allows secure access to most of the issue resolution data. Of course, you're free to pull in data from other sources. 
+For convenience, a [query hook](src/helpers/useQuery.ts) is provided that allows secure access to most of the issue resolution data. Of course, you're free to pull in data from other sources.
 
 ## Routes
 Routes define a browser path to your dashboard within Cloud Pak for AIOps. This includes how components are organized and whether they're exposed in the Cloud Pak for AIOps main menu. An [example](config/routes.json) for local development is provided.
@@ -16,6 +16,7 @@ Routes define a browser path to your dashboard within Cloud Pak for AIOps. This 
 Visit our [storybook](https://ibm.github.io/aiops-ui-extension-template) for examples based on real Netcool customers.
 
 You can also install the examples into an actual Cloud Pak for AIOps cluster.
+For a guide on embedding a Grafana page, see the doc [here](doc/grafana-guide.md).
 
 ## Ready to start building?
 See our [getting started](doc/getting-started.md) page for the step-by-step process.

--- a/doc/grafana-guide.md
+++ b/doc/grafana-guide.md
@@ -1,0 +1,42 @@
+# Grafana embedding
+
+## Prerequisites
+- Cloud Pak for AIOps cluster
+- UI extension [prerequisites](https://github.com/IBM/aiops-ui-extension-template/blob/main/doc/getting-started.md#step-by-step) completed:
+  - 1. Fork...
+  - 2. Install...
+  - 3. Enable...
+- Grafana instance
+
+## Step-by-step
+#### 1. Ensure the prerequisites are completed. At this stage, you should be able to access your cluster and find the default instance of the AIOps UI Extension custom resource:
+  ```
+    $ oc get AIOpsUIExtension -n aiops
+    NAME                      READY   MESSAGE
+    aiopsuiextension-sample   True    READY FOR E-BUSINESS...
+  ```
+
+#### 2. Edit the `aiopsuiextension-sample` custom resource and add the following `spec`:
+```
+$ oc patch AIOpsUIExtension aiopsuiextension-sample --type merge -p '
+spec:
+  menuRoutes:
+    - categoryTitle: Example dashboards
+      routes:
+        - /embedded-grafana
+      type: category
+  routes:
+    - path: /embedded-grafana
+      title: Grafana
+      url: 'https://your-grafana-url.com:3000'
+' -n aiops
+```
+_Notes:_
+  - _Adjust the url/port to be applicable to your instance._
+  - _This specification of menu routes creates a new folder in the nav named 'Example dashboards', that will then have the 'Grafana' page in it._
+  - _If you alredy have an existing `AIOpsUIExtension` then you can use that and add a new route to the same effect._
+
+#### 3. Edit your grafana configuration to allow embedding: https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#allow_embedding.
+
+#### 4. Navigate to your CP4AIOps instance and the newly created page: https://cpd-aiops.apps.your-aiops-cluster.your-domain.com/aiops/cfd95b7e-3bc7-4006-a4a8-a73a79c71255/page/embedded-grafana
+

--- a/doc/grafana-guide.md
+++ b/doc/grafana-guide.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 - Cloud Pak for AIOps cluster
-- UI extension [prerequisites](https://github.com/IBM/aiops-ui-extension-template/blob/main/doc/getting-started.md#step-by-step) completed:
+- UI extension [prerequisites](getting-started.md#step-by-step) completed:
   - 1. Fork...
   - 2. Install...
   - 3. Enable...
@@ -17,24 +17,30 @@
   ```
 
 #### 2. Edit the `aiopsuiextension-sample` custom resource and add the following `spec`:
+Update the config in `config/routes.json` to include the following new routes and run `npm run examples -- -n <AIOps namespace> ` to update the AIOpsUIExtension on the cluster. If you are not intending to use the other toolkit samples, you can simply remove them from the `config/routes.json` file at this stage.
 ```
-$ oc patch AIOpsUIExtension aiopsuiextension-sample --type merge -p '
-spec:
-  menuRoutes:
-    - categoryTitle: Example dashboards
-      routes:
-        - /embedded-grafana
-      type: category
-  routes:
-    - path: /embedded-grafana
-      title: Grafana
-      url: 'https://your-grafana-url.com:3000'
-' -n aiops
+{
+  "menuRoutes": [
+    {
+      "categoryTitle": "Grafana dashboards",
+      "routes": [
+          "/embedded-grafana
+      ],
+      "type": "category"
+    }
+  ],
+  "routes": [
+    {
+      "path": "/embedded-grafana",
+      "title": "Grafana",
+      "url": "https://your-grafana-url.com:3000"
+    }
+  ]
+}
 ```
 _Notes:_
   - _Adjust the url/port to be applicable to your instance._
-  - _This specification of menu routes creates a new folder in the nav named 'Example dashboards', that will then have the 'Grafana' page in it._
-  - _If you alredy have an existing `AIOpsUIExtension` then you can use that and add a new route to the same effect._
+  - _This specification of menu routes creates a new folder in the nav named 'Grafana dashboards', that will then have the 'Grafana' page in it._
 
 #### 3. Edit your grafana configuration to allow embedding: https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#allow_embedding.
 


### PR DESCRIPTION
Adds a simple guide for embedding Grafana pages into CP4AIOps. Could be extended to other similar examples and will add more specifics in future.