### PR TITLE
Adjust default namespace

### DIFF
--- a/enable.mjs
+++ b/enable.mjs
@@ -15,7 +15,7 @@ const defaultTarget = {
   bundleName: 'alerts-examples'
 };
 const defaultFeatureFlag = 'USE_CUSTOM_DASHBOARD';
-const defaultNamespace = 'cp4waiops';
+const defaultNamespace = 'cp4aiops';
 const extensionsConfigMap = 'aiops-ir-ui-extensions';
 const featureConfigMap = 'feature-flag-configmap';
 const labelSelectorBundle = 'component=aiops-ir-ui-bundle-api';

--- a/examples.mjs
+++ b/examples.mjs
@@ -8,7 +8,7 @@ import { readFileSync } from 'fs';
 import minimist from 'minimist';
 
 const defaultCr = 'aiopsuiextension-sample';
-const defaultNamespace = 'cp4waiops';
+const defaultNamespace = 'cp4aiops';
 
 const addExamples = (finalSpec, namespace, cr) => {
   let newSpec = JSON.stringify(finalSpec);


### PR DESCRIPTION
As of recent version of CP4AIOps, the default namespace has changed. This PR adjusts that accordingly. 